### PR TITLE
Support packaging 26.0 changes

### DIFF
--- a/tests/pip_requirements_parser_tests/unit/test_req.py
+++ b/tests/pip_requirements_parser_tests/unit/test_req.py
@@ -44,13 +44,13 @@ class TestInstallRequirement(TestCase):
     def test_pep440_wheel_link_requirement(self) -> None:
         line = "test @ https://whatever.com/test-0.4-py2.py3-bogus-any.whl"
         req = build_install_req(line)
-        assert str(req.req) == "test@ https://whatever.com/test-0.4-py2.py3-bogus-any.whl"
+        assert str(req.req) == "test @ https://whatever.com/test-0.4-py2.py3-bogus-any.whl"
         assert str(req.link) == "https://whatever.com/test-0.4-py2.py3-bogus-any.whl"
 
     def test_pep440_url_link_requirement(self) -> None:
         line = "foo @ git+http://foo.com@ref#egg=foo"
         req = build_install_req(line)
-        assert str(req.req) == "foo@ git+http://foo.com@ref#egg=foo"
+        assert str(req.req) == "foo @ git+http://foo.com@ref#egg=foo"
         assert str(req.link) == "git+http://foo.com@ref#egg=foo"
 
     def test_url_with_authentication_link_requirement(self) -> None:

--- a/tests/pip_requirements_parser_tests/unit/test_req_file.py
+++ b/tests/pip_requirements_parser_tests/unit/test_req_file.py
@@ -358,7 +358,7 @@ class TestProcessFile:
         assert r.name == "SomeProject"
         assert not r.specifier
         assert r.extras == set()
-        assert str(r) == "SomeProject@ http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
+        assert str(r) == "SomeProject @ http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
 
     def test_parse_name_at_url__with_packaging(self, parse_requirement_text) -> None:
         from packaging.requirements import Requirement
@@ -369,7 +369,7 @@ class TestProcessFile:
         assert r.name == "SomeProject"
         assert not r.specifier
         assert r.extras == set()
-        assert str(r) == "SomeProject@ http://my.package.repo/SomeProject2.tgz"
+        assert str(r) == "SomeProject @ http://my.package.repo/SomeProject2.tgz"
 
     def test_parse_name_at_vcs_url_to_wheel_with_packaging(self, parse_requirement_text) -> None:
         from packaging.requirements import Requirement
@@ -380,7 +380,7 @@ class TestProcessFile:
         assert r.name == "SomeProject"
         assert not r.specifier
         assert r.extras == set()
-        assert str(r) == "SomeProject@ git+http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
+        assert str(r) == "SomeProject @ git+http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
 
     def test_can_dumps_name_at_url_to_wheel(self, parse_requirement_text) -> None:
         text = "SomeProject@http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
@@ -394,7 +394,7 @@ class TestProcessFile:
         assert not r.specifier
         assert r.link.url == "http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
         assert r.extras == set()
-        assert str(r.req) ==  "SomeProject@ http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
+        assert str(r.req) ==  "SomeProject @ http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
         assert r.dumps() == text
 
     def test_can_dumps_name_at_url_to_wheel_with_space(self, parse_requirement_text) -> None:
@@ -409,7 +409,7 @@ class TestProcessFile:
         assert not r.specifier
         assert r.link.url == "http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
         assert r.extras == set()
-        assert str(r.req) == "SomeProject@ http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
+        assert str(r.req) == "SomeProject @ http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
         assert r.dumps() == "SomeProject@http://my.package.repo/SomeProject2-1.2.3-py33-none-any.whl"
 
     def test_can_dumps_name_at_vcs_url_to_wheel(self, parse_requirement_text) -> None:

--- a/tests/test_pip_api_parse_requirements.py
+++ b/tests/test_pip_api_parse_requirements.py
@@ -114,8 +114,8 @@ class Pep508Test(NamedTuple):
             req_name="pip",
             req_url="https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4",
             link_url="https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4",
-            # Note extra space after @
-            req_string="pip@ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4",
+            # Note extra space before and after @
+            req_string="pip @ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4",
             req_spec="",
         ),
         Pep508Test(
@@ -124,8 +124,8 @@ class Pep508Test(NamedTuple):
             req_name="pip",
             req_url="https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4",
             link_url="https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4",
-            # Note extra space after @
-            req_string="pip@ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4",
+            # Note extra space before and after @
+            req_string="pip @ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4",
             req_spec="",
         ),
         Pep508Test(


### PR DESCRIPTION
Packaging 26.0 changed the string representation of requirements with URLs, sprinkle in more spaces.

Closes #27